### PR TITLE
Read configuration from AWS Parameter Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ Follow these steps:
 
 ### Example command for `slink-main` function, passing in Lambda environment variable:
 
-`SR_API_TOKEN=<value> SAP_USERNAME=<value> SAP_PASSWORD=<value> sam local invoke SlinkMainFunction -e event.json`
+sam local invoke SlinkMainFunction -e event.json`
+
+_**Note**_: Runtime configuration settings are managed in AWS Parameter Store. There are two sets of configuration settings 
+for STAGE and PROD environments. When running locally via SAM local, we use the STAGE configuration. The parameters are 
+managed under /slink path in AWS Parameter Store.
 
 
 ## AWS Deployment ##

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "eslint-plugin-react": "^7.8.2",
     "jest": "^22.4.4",
     "jest-get-type": "^22.4.3",
-    "pre-commit": "^1.2.2"
+    "pre-commit": "^1.2.2",
+    "aws-sdk": "^2.259.1",
+    "aws-param-store": "^2.0.0"
   },
   "engines": {
     "node": ">=8.0.0"
@@ -30,5 +32,6 @@
   "precommit": [
     "eslint",
     "test"
-  ]
+  ],
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "jest": "^22.4.4",
     "jest-get-type": "^22.4.3",
     "pre-commit": "^1.2.2",
-    "aws-sdk": "^2.259.1",
-    "aws-param-store": "^2.0.0"
+    "aws-sdk": "2.259.1",
+    "aws-param-store": "2.0.0"
   },
   "engines": {
     "node": ">=8.0.0"

--- a/slink-main/aws.js
+++ b/slink-main/aws.js
@@ -8,11 +8,11 @@ const awsParamStore = require('aws-param-store');
  * @param paramPath
  * @returns Parameter keys/values raw JSON
  */
-const getAWSParams = async (paramPath, awsRegion) => {
+const getParams = async (paramPath, awsRegion) => {
   const parameters = await awsParamStore.getParametersByPath(paramPath, { region: awsRegion });
   return parameters;
 };
 
 module.exports = {
-  getAWSParams
+  getParams
 };

--- a/slink-main/aws.js
+++ b/slink-main/aws.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const awsParamStore = require('aws-param-store');
+
+/**
+ * Helper function to call AWS API to retrieve parameter values
+ * Extracting this call in its own function also helps in mocking tests
+ * @param paramPath
+ * @returns Parameter keys/values raw JSON
+ */
+const getAWSParams = async (paramPath, awsRegion) => {
+  const parameters = await awsParamStore.getParametersByPath(paramPath, { region: awsRegion });
+  return parameters;
+};
+
+module.exports = {
+  getAWSParams
+};

--- a/slink-main/config.js
+++ b/slink-main/config.js
@@ -1,0 +1,108 @@
+'use strict';
+
+const awsParamStore = require('aws-param-store');
+
+const configParams = {
+  SAP_ADD_EMPLOYEE_URL: {
+    name: 'sap/ADD_EMPLOYEE_URL',
+    value: undefined
+  },
+  SAP_USERNAME: {
+    name: 'sap/USERNAME',
+    value: undefined
+  },
+  SAP_PASSWORD: {
+    name: 'sap/PASSWORD',
+    value: undefined
+  },
+  SR_ADD_PROP_URL: {
+    name: 'smartrecruiters/ADD_PROP_URL',
+    value: undefined
+  },
+  SR_EMPLOYEE_PROP_ID: {
+    name: 'smartrecruiters/EMPLOYEE_PROP_ID',
+    value: undefined
+  },
+  SR_JOB_PROPS_URL: {
+    name: 'smartrecruiters/JOB_PROPS_URL',
+    value: undefined
+  },
+  SR_SUMMARY_URL: {
+    name: 'smartrecruiters/SUMMARY_URL',
+    value: undefined
+  },
+  SR_TOKEN: {
+    name: 'smartrecruiters/TOKEN',
+    value: undefined
+  }
+};
+
+/**
+ * Helper function to call AWS API to retrieve parameter values
+ * Extracting this call in its own function also helps in mocking tests
+ * @param paramPath
+ * @returns Parameter keys/values raw JSON
+ */
+const getAWSParams = async (paramPath) => {
+  // Get the AWS region from the environment variable which gets created automatically by AWS
+  let awsRegion = process.env.AWS_DEFAULT_REGION;
+
+  // the environment doesn't know which AWS region we are running in so default it to us-east-1
+  if (awsRegion === undefined) {
+    awsRegion = 'us-east-1';
+  }
+
+  const parameters = await awsParamStore.getParametersByPath(paramPath, { region: awsRegion });
+  return parameters;
+};
+
+// This is an awful work around to mocking a single function using jest!!
+// Apparently mocking a single function in a module doesn't work!
+const lib = {
+  getAWSParams,
+};
+
+/**
+ * Loads the configuration paramaters from AWS Parameter Store.<br/>
+ * It uses the Lambda ALIAS to determine which paramaters to load (STAGE or PROD).<br/>
+ * In order for this work correctly, we must ensure that the Lambda functions have aliases assigned
+ * to a specific version.<br/>
+ *
+ * @returns {} JSON with all the parameters for the current environment/alias
+ */
+const loadConfigParams = async (context) => {
+  const functionName = { context };
+  const functionArn = context.invokedFunctionArn;
+
+  let alias = functionArn.split(':').pop();
+
+  // the ARN doesn't include an alias token, therefore we must be executing $LATEST
+  if (alias === functionName) {
+    alias = 'LATEST';
+  }
+  const paramPath = `/slink/${alias}`;
+
+  const parameters = await lib.getAWSParams(paramPath);
+  // console.log(`SSM Params: ${JSON.stringify(parameters)}`);
+
+  // Load all param values in our configParams list
+  const keys = Object.keys(configParams);
+  keys.forEach((configParamKey) => {
+    const configParam = configParams[configParamKey];
+    const paramFound = parameters.filter(p => p.Name.includes(configParam.name));
+    if (paramFound !== undefined && paramFound.length === 1) {
+      configParam.value = paramFound[0].Value;
+    } else {
+      // We didn't find something here so its best to throw an exception and stop
+      throw new Error(`Configuration value not found in SSM Parameter Store for: ${configParam.name}`);
+    }
+  });
+
+  return configParams;
+};
+
+module.exports = {
+  loadConfigParams,
+  lib,
+  configParams
+};

--- a/slink-main/config.js
+++ b/slink-main/config.js
@@ -70,7 +70,7 @@ const loadConfigParams = async (context) => {
     console.log(`#### Defaulting to ${awsRegion} region for AWS API calls`);
   }
 
-  const parameters = await aws.getAWSParams(paramPath);
+  const parameters = await aws.getParams(paramPath);
   // console.log(`SSM Params: ${JSON.stringify(parameters)}`);
 
   // Load all param values in our configParams list

--- a/slink-main/config.js
+++ b/slink-main/config.js
@@ -79,7 +79,11 @@ const loadConfigParams = async (context) => {
   // the ARN doesn't include an alias token, therefore we must be executing $LATEST
   if (alias === functionName) {
     alias = 'LATEST';
+  } else if (alias === 'test') {
+    // If running locally, AWS automatically sets alias to 'test' so we will change it to STAGE for testing purposes
+    alias = 'STAGE';
   }
+
   const paramPath = `/slink/${alias}`;
 
   const parameters = await lib.getAWSParams(paramPath);
@@ -94,7 +98,7 @@ const loadConfigParams = async (context) => {
       configParam.value = paramFound[0].Value;
     } else {
       // We didn't find something here so its best to throw an exception and stop
-      throw new Error(`Configuration value not found in SSM Parameter Store for: ${configParam.name}`);
+      throw new Error(`Configuration value not found in SSM Parameter Store for: ${paramPath}/${configParam.name}`);
     }
   });
 

--- a/slink-main/index.js
+++ b/slink-main/index.js
@@ -1,11 +1,15 @@
 'use strict';
 
 const introduction = require('./introduction');
+const config = require('./config');
 
 module.exports.handler = async (event, context, callback) => {
   try {
     console.log(`#### All the context stuff:  ${JSON.stringify(context)}`);
     console.log(`#### Function ARN:  ${context.invokedFunctionArn}`);
+
+    // Load all configuration parameters from AWS SSM
+    await config.loadConfigParams(context);
 
     const result = await introduction.process();
 

--- a/slink-main/package.json
+++ b/slink-main/package.json
@@ -3,6 +3,8 @@
     "version": "0.0.1",
     "private": true,
     "dependencies": {
+        "aws-sdk": "^2.259.1",
+        "aws-param-store": "^2.0.0",
         "axios": "0.18.0"
     },
     "devDependencies": {

--- a/slink-main/sap.js
+++ b/slink-main/sap.js
@@ -16,12 +16,12 @@ const DEFAULT_ZIP_CODE = '40391'; // Unlikely marker zip code because SAP appear
  */
 const postApplicant = async (applicant, resumeNumber) => {
   try {
-    const apiEndpoint = config.configParams.SAP_ADD_EMPLOYEE_URL;
+    const apiEndpoint = config.params.SAP_ADD_EMPLOYEE_URL;
     const options = {
       method: 'POST',
       headers: {
-        Username: config.configParams.SAP_USERNAME,
-        Password: config.configParams.SAP_PASSWORD,
+        Username: config.params.SAP_USERNAME,
+        Password: config.params.SAP_PASSWORD,
         'Content-Type': 'application/json'
       }
     };

--- a/slink-main/sap.js
+++ b/slink-main/sap.js
@@ -2,6 +2,7 @@
 
 const axios = require('axios');
 const util = require('./util');
+const config = require('./config');
 
 const MISSING_STRING = '';
 const DEFAULT_STRING = 'NA';
@@ -15,12 +16,12 @@ const DEFAULT_ZIP_CODE = '40391'; // Unlikely marker zip code because SAP appear
  */
 const postApplicant = async (applicant, resumeNumber) => {
   try {
-    const apiEndpoint = process.env.SAP_ADD_EMPLOYEE_URL;
+    const apiEndpoint = config.configParams.SAP_ADD_EMPLOYEE_URL;
     const options = {
       method: 'POST',
       headers: {
-        Username: process.env.SAP_USERNAME,
-        Password: process.env.SAP_PASSWORD,
+        Username: config.configParams.SAP_USERNAME,
+        Password: config.configParams.SAP_PASSWORD,
         'Content-Type': 'application/json'
       }
     };

--- a/slink-main/smartrecruiters.js
+++ b/slink-main/smartrecruiters.js
@@ -1,10 +1,11 @@
 'use strict';
 
 const axios = require('axios');
+const config = require('./config');
 
 const srGet = async (url) => {
   try {
-    const apiToken = process.env.SR_API_TOKEN;
+    const apiToken = config.configParams.SR_TOKEN;
     const options = {
       method: 'GET',
       headers: { 'X-SmartToken': apiToken }
@@ -26,7 +27,7 @@ const srGet = async (url) => {
 };
 
 const getJobProperties = async (candidateId, jobId) => {
-  let apiEndpoint = process.env.SR_JOB_PROPS_URL;
+  let apiEndpoint = config.configParams.SR_JOB_PROPS_URL;
   if (apiEndpoint != null) {
     apiEndpoint = apiEndpoint.replace('{candidateId}', candidateId);
     apiEndpoint = apiEndpoint.replace('{jobId}', jobId);
@@ -52,7 +53,7 @@ const getValue = property => (property != null ? property.value : null);
 const getCode = property => (property != null ? property.code : null);
 
 const getApplicants = async () => {
-  const summaries = await srGet(process.env.SR_CANDIDATE_SUMMARY_URL);
+  const summaries = await srGet(config.configParams.SR_SUMMARY_URL);
 
   const applicants = Promise.all(summaries.content.map(async (summary) => {
     const candidateDetail = await srGet(summary.actions.details.url);
@@ -62,7 +63,7 @@ const getApplicants = async () => {
     const salaryPropertyValue = findPropertyValueByLabel(jobProps.content, 'Annual Salary');
     const annualBonusValue = findPropertyValueByLabel(jobProps.content, 'Annual Bonus');
     const signingBonusValue = findPropertyValueByLabel(jobProps.content, 'Signing Bonus');
-    const employeeId = findPropertyValueById(jobProps.content, process.env.SR_EMPLOYEE_PROP_ID);
+    const employeeId = findPropertyValueById(jobProps.content, config.configParams.SR_EMPLOYEE_PROP_ID);
 
     const applicant = {
       id: summary.id,
@@ -110,11 +111,11 @@ const getApplicants = async () => {
  */
 const addEmployeeId = async (applicantId, jobId, sapId) => {
   try {
-    const apiToken = process.env.SR_API_TOKEN;
-    let apiEndpoint = process.env.SR_ADD_PROPERTY_URL;
+    const apiToken = config.configParams.SR_TOKEN;
+    let apiEndpoint = config.configParams.SR_ADD_PROP_URL;
     apiEndpoint = apiEndpoint.replace('{candidateId}', applicantId);
     apiEndpoint = apiEndpoint.replace('{jobId}', jobId);
-    apiEndpoint = apiEndpoint.replace('{propertyId}', process.env.SR_EMPLOYEE_PROP_ID);
+    apiEndpoint = apiEndpoint.replace('{propertyId}', config.configParams.SR_EMPLOYEE_PROP_ID);
 
     const options = {
       method: 'PUT',

--- a/slink-main/smartrecruiters.js
+++ b/slink-main/smartrecruiters.js
@@ -5,7 +5,7 @@ const config = require('./config');
 
 const srGet = async (url) => {
   try {
-    const apiToken = config.configParams.SR_TOKEN;
+    const apiToken = config.params.SR_TOKEN;
     const options = {
       method: 'GET',
       headers: { 'X-SmartToken': apiToken }
@@ -27,7 +27,7 @@ const srGet = async (url) => {
 };
 
 const getJobProperties = async (candidateId, jobId) => {
-  let apiEndpoint = config.configParams.SR_JOB_PROPS_URL;
+  let apiEndpoint = config.params.SR_JOB_PROPS_URL;
   if (apiEndpoint != null) {
     apiEndpoint = apiEndpoint.replace('{candidateId}', candidateId);
     apiEndpoint = apiEndpoint.replace('{jobId}', jobId);
@@ -53,7 +53,7 @@ const getValue = property => (property != null ? property.value : null);
 const getCode = property => (property != null ? property.code : null);
 
 const getApplicants = async () => {
-  const summaries = await srGet(config.configParams.SR_SUMMARY_URL);
+  const summaries = await srGet(config.params.SR_SUMMARY_URL);
 
   const applicants = Promise.all(summaries.content.map(async (summary) => {
     const candidateDetail = await srGet(summary.actions.details.url);
@@ -63,7 +63,7 @@ const getApplicants = async () => {
     const salaryPropertyValue = findPropertyValueByLabel(jobProps.content, 'Annual Salary');
     const annualBonusValue = findPropertyValueByLabel(jobProps.content, 'Annual Bonus');
     const signingBonusValue = findPropertyValueByLabel(jobProps.content, 'Signing Bonus');
-    const employeeId = findPropertyValueById(jobProps.content, config.configParams.SR_EMPLOYEE_PROP_ID);
+    const employeeId = findPropertyValueById(jobProps.content, config.params.SR_EMPLOYEE_PROP_ID);
 
     const applicant = {
       id: summary.id,
@@ -111,11 +111,11 @@ const getApplicants = async () => {
  */
 const addEmployeeId = async (applicantId, jobId, sapId) => {
   try {
-    const apiToken = config.configParams.SR_TOKEN;
-    let apiEndpoint = config.configParams.SR_ADD_PROP_URL;
+    const apiToken = config.params.SR_TOKEN;
+    let apiEndpoint = config.params.SR_ADD_PROP_URL;
     apiEndpoint = apiEndpoint.replace('{candidateId}', applicantId);
     apiEndpoint = apiEndpoint.replace('{jobId}', jobId);
-    apiEndpoint = apiEndpoint.replace('{propertyId}', config.configParams.SR_EMPLOYEE_PROP_ID);
+    apiEndpoint = apiEndpoint.replace('{propertyId}', config.params.SR_EMPLOYEE_PROP_ID);
 
     const options = {
       method: 'PUT',

--- a/slink-main/tests/int/smartrecruiters_int_test.js
+++ b/slink-main/tests/int/smartrecruiters_int_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const smartrecruiters = require('../../smartrecruiters');
+const config = require('../../config');
 
 const applicantId = 'cc285818-963d-497a-a2a8-e2227af0876e';
 const jobId = 'ccfc86f3-c309-48e2-a2ae-175ae0d0ec3c';
@@ -8,9 +9,8 @@ const employeeId = 'test-ccfc86f3-c309';
 
 describe('Add & then delete/null out Employee Id property in SR', () => {
   beforeAll(() => {
-    // process.env.SR_API_TOKEN = 'set me in the env';
-    process.env.SR_EMPLOYEE_PROP_ID = '05f1b2eb-65f2-46c7-ad73-c7b8bd688c33';
-    process.env.SR_ADD_PROPERTY_URL = 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties/{propertyId}';
+    config.configParams.SR_EMPLOYEE_PROP_ID = '05f1b2eb-65f2-46c7-ad73-c7b8bd688c33';
+    config.configParams.SR_JOB_PROPS_URL = 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties/{propertyId}';
   });
 
   beforeEach(() => {

--- a/slink-main/tests/int/smartrecruiters_int_test.js
+++ b/slink-main/tests/int/smartrecruiters_int_test.js
@@ -9,8 +9,8 @@ const employeeId = 'test-ccfc86f3-c309';
 
 describe('Add & then delete/null out Employee Id property in SR', () => {
   beforeAll(() => {
-    config.configParams.SR_EMPLOYEE_PROP_ID = '05f1b2eb-65f2-46c7-ad73-c7b8bd688c33';
-    config.configParams.SR_JOB_PROPS_URL = 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties/{propertyId}';
+    config.params.SR_EMPLOYEE_PROP_ID = '05f1b2eb-65f2-46c7-ad73-c7b8bd688c33';
+    config.params.SR_JOB_PROPS_URL = 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties/{propertyId}';
   });
 
   beforeEach(() => {

--- a/slink-main/tests/unit/config_test.js
+++ b/slink-main/tests/unit/config_test.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const config = require('../../config.js');
+
+describe('Handler invocation', () => {
+  beforeEach(() => {
+    config.lib.getAWSParams.mockClear();
+  });
+
+  const context = {
+    functionName: 'awscodestar-buildit-slink-lambda-SlinkMainFunction-ABBXZIYEV8GR',
+    invokedFunctionArn: 'arn:aws:lambda:us-east-1:006393696278:function:awscodestar-buildit-slink-lambda-SlinkMainFunction-ABBXZIYEV8GR:STAGE'
+  };
+
+  const mockedAWSParamResult = {
+    data: [
+      {
+        Name: '/slink/STAGE/sap/ADD_EMPLOYEE_URL',
+        Value: 'https://appstore.wipro.com/synergy/AltRecruitService?opr=empIdGen'
+      },
+      {
+        Name: '/slink/STAGE/sap/PASSWORD',
+        Value: 'password'
+      },
+      {
+        Name: '/slink/STAGE/sap/USERNAME',
+        Value: 'username'
+      },
+      {
+        Name: '/slink/STAGE/smartrecruiters/ADD_PROP_URL',
+        Value: 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties/{propertyId}'
+      },
+      {
+        Name: '/slink/STAGE/smartrecruiters/EMPLOYEE_PROP_ID',
+        Value: '05f1b2eb-65f2-46c7-ad73-c7b8bd688c33'
+      },
+      {
+        Name: '/slink/STAGE/smartrecruiters/JOB_PROPS_URL',
+        Value: 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties'
+      },
+      {
+        Name: '/slink/STAGE/smartrecruiters/SUMMARY_URL',
+        Value: 'https://api.smartrecruiters.com/candidates?status=OFFERED&subStatus=Offer Accepted'
+      },
+      {
+        Name: '/slink/STAGE/smartrecruiters/TOKEN',
+        Value: 'xxxxxxxxxx'
+      }
+    ]
+  };
+
+  const mockedExpectedResult = {
+    SAP_ADD_EMPLOYEE_URL: {
+      name: 'sap/ADD_EMPLOYEE_URL',
+      value: 'https://appstore.wipro.com/synergy/AltRecruitService?opr=empIdGen'
+    },
+    SAP_USERNAME: {
+      name: 'sap/USERNAME',
+      value: 'username'
+    },
+    SAP_PASSWORD: {
+      name: 'sap/PASSWORD',
+      value: 'password'
+    },
+    SR_ADD_PROP_URL: {
+      name: 'smartrecruiters/ADD_PROP_URL',
+      value: 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties/{propertyId}'
+    },
+    SR_EMPLOYEE_PROP_ID: {
+      name: 'smartrecruiters/EMPLOYEE_PROP_ID',
+      value: '05f1b2eb-65f2-46c7-ad73-c7b8bd688c33'
+    },
+    SR_JOB_PROPS_URL: {
+      name: 'smartrecruiters/JOB_PROPS_URL',
+      value: 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties'
+    },
+    SR_SUMMARY_URL: {
+      name: 'smartrecruiters/SUMMARY_URL',
+      value: 'https://api.smartrecruiters.com/candidates?status=OFFERED&subStatus=Offer Accepted'
+    },
+    SR_TOKEN: {
+      name: 'smartrecruiters/TOKEN',
+      value: 'xxxxxxxxxx'
+    }
+  };
+
+  const mockedBadAWSParamResult = {
+    data: [
+      {
+        Name: '/slink/STAGE/sap/ADD_EMPLOYEE_URL',
+        Value: 'https://appstore.wipro.com/synergy/AltRecruitService?opr=empIdGen'
+      }
+    ]
+  };
+
+  config.lib.getAWSParams = jest.fn(() => {return mockedAWSParamResult.data;});
+
+  it('checks if all parameters are defined in AWS paramater store', async () => {
+    try {
+      const configParams = await config.loadConfigParams(context);
+      expect(JSON.stringify(configParams) === JSON.stringify(mockedExpectedResult)).toBe(true);
+    } catch (e) {
+      throw new Error(`Error: ${e.message}`);
+    }
+  });
+
+  it('throws an exception on failure', async () => {
+    config.lib.getAWSParams = jest.fn(() => {
+      return mockedBadAWSParamResult.data;
+    });
+
+    await expect(config.loadConfigParams(context)).rejects.toBeDefined();
+  });
+});

--- a/slink-main/tests/unit/config_test.js
+++ b/slink-main/tests/unit/config_test.js
@@ -7,7 +7,7 @@ jest.mock('../../aws.js');
 
 describe('Handler invocation', () => {
   beforeEach(() => {
-    aws.getAWSParams.mockClear();
+    aws.getParams.mockClear();
   });
 
   const context = {
@@ -89,7 +89,7 @@ describe('Handler invocation', () => {
 
   it('checks if all parameters are defined in AWS parameter store', async () => {
     try {
-      aws.getAWSParams.mockResolvedValue(mockedAWSParamResult.data);
+      aws.getParams.mockResolvedValue(mockedAWSParamResult.data);
       const configParams = await config.loadConfigParams(context);
       expect(JSON.stringify(configParams) === JSON.stringify(mockedExpectedResult)).toBe(true);
     } catch (e) {
@@ -99,7 +99,7 @@ describe('Handler invocation', () => {
 
   it('throws an exception on failure', async () => {
     const error = new Error('Error from unit test');
-    aws.getAWSParams.mockRejectedValue(error);
+    aws.getParams.mockRejectedValue(error);
     return (config.loadConfigParams(context)).rejects;
   });
 });

--- a/slink-main/tests/unit/index_test.js
+++ b/slink-main/tests/unit/index_test.js
@@ -3,8 +3,10 @@
 const getType = require('jest-get-type');
 const index = require('../../index.js');
 const introduction = require('../../introduction');
+const config = require('../../config');
 
 jest.mock('../../introduction');
+jest.mock('../../config');
 
 const context = { invokedFunctionArn: 'unit-test' };
 
@@ -25,8 +27,10 @@ describe('Handler invocation', () => {
   });
 
   it('runs introduction process and gives unsuccessful response if issues', async () => {
+    config.loadConfigParams.mockResolvedValue({ SAP_ADD_EMPLOYEE_URL: '' });
     introduction.process.mockRejectedValue(new Error('Some random error occurred'));
     await index.handler({}, context, (err, result) => {
+      console.log(`error: ${err}`);
       expect(result.statusCode).toEqual(500);
       expect(getType(result.body)).toEqual('object');
       expect(result.body).toEqual({ message: 'Error: Some random error occurred' });

--- a/slink-main/tests/unit/sap_test.js
+++ b/slink-main/tests/unit/sap_test.js
@@ -2,6 +2,7 @@
 
 const axios = require('axios');
 const sap = require('../../sap');
+const config = require('../../config');
 const testmodels = require('./models');
 
 jest.mock('axios');
@@ -29,9 +30,9 @@ const mockResponseBad = {
 
 describe('POSTing Employee Data', () => {
   beforeAll(() => {
-    process.env.SAP_USERNAME = 'username';
-    process.env.SAP_PASSWORD = 'password';
-    process.env.SR_CANDIDATE_SUMMARY_URL = 'http://mockurl/';
+    config.configParams.SAP_USERNAME = 'username';
+    config.configParams.SAP_PASSWORD = 'password';
+    config.configParams.SR_SUMMARY_URL = 'http://mockurl/';
   });
 
   beforeEach(() => {

--- a/slink-main/tests/unit/sap_test.js
+++ b/slink-main/tests/unit/sap_test.js
@@ -30,9 +30,9 @@ const mockResponseBad = {
 
 describe('POSTing Employee Data', () => {
   beforeAll(() => {
-    config.configParams.SAP_USERNAME = 'username';
-    config.configParams.SAP_PASSWORD = 'password';
-    config.configParams.SR_SUMMARY_URL = 'http://mockurl/';
+    config.params.SAP_USERNAME = 'username';
+    config.params.SAP_PASSWORD = 'password';
+    config.params.SR_SUMMARY_URL = 'http://mockurl/';
   });
 
   beforeEach(() => {

--- a/slink-main/tests/unit/smartrecruiters_test.js
+++ b/slink-main/tests/unit/smartrecruiters_test.js
@@ -13,9 +13,9 @@ describe('Get candidate summary', () => {
   const { get } = axios;
 
   beforeAll(() => {
-    config.configParams.SR_SUMMARY_URL = 'http://mockurl/';
-    config.configParams.SR_JOB_PROPS_URL = 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties';
-    config.configParams.SR_EMPLOYEE_PROP_ID = 'abc-123';
+    config.params.SR_SUMMARY_URL = 'http://mockurl/';
+    config.params.SR_JOB_PROPS_URL = 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties';
+    config.params.SR_EMPLOYEE_PROP_ID = 'abc-123';
   });
 
   beforeEach(() => {
@@ -40,7 +40,7 @@ describe('Get candidate summary', () => {
   it('builds applicant employee ID if property is present', async () => {
     const jobPropertiesWithEmployeeId = Object.assign({}, testmodels.sr.jobProperties);
     jobPropertiesWithEmployeeId.data.content.push({
-      id: config.configParams.SR_EMPLOYEE_PROP_ID,
+      id: config.params.SR_EMPLOYEE_PROP_ID,
       value: 12345
     });
     get.mockResolvedValueOnce(jobPropertiesWithEmployeeId);
@@ -63,7 +63,7 @@ describe('Get candidate summary', () => {
 
   function expectSmartRecruitersCalls(get) {
     expect(get.mock.calls[0][0])
-      .toBe(config.configParams.SR_SUMMARY_URL);
+      .toBe(config.params.SR_SUMMARY_URL);
     expect(get.mock.calls[1][0])
       .toBe(testmodels.sr.rawCandidateSummaries.data.content[0].actions.details.url);
     expect(get.mock.calls[2][0])
@@ -91,7 +91,7 @@ describe('Add Employee Id property to SR', () => {
   };
 
   beforeAll(() => {
-    config.configParams.SR_ADD_PROP_URL = 'http://mockurl/';
+    config.params.SR_ADD_PROP_URL = 'http://mockurl/';
   });
 
   beforeEach(() => {

--- a/slink-main/tests/unit/smartrecruiters_test.js
+++ b/slink-main/tests/unit/smartrecruiters_test.js
@@ -3,6 +3,7 @@
 const axios = require('axios');
 const smartrecruiters = require('../../smartrecruiters');
 const testmodels = require('./models');
+const config = require('../../config');
 
 jest.mock('axios');
 
@@ -12,10 +13,9 @@ describe('Get candidate summary', () => {
   const { get } = axios;
 
   beforeAll(() => {
-    process.env.SR_API_TOKEN = 'SR_API_TOKEN';
-    process.env.SR_CANDIDATE_SUMMARY_URL = 'http://mockurl/';
-    process.env.SR_JOB_PROPS_URL = 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties';
-    process.env.SR_EMPLOYEE_PROP_ID = 'abc-123';
+    config.configParams.SR_SUMMARY_URL = 'http://mockurl/';
+    config.configParams.SR_JOB_PROPS_URL = 'https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties';
+    config.configParams.SR_EMPLOYEE_PROP_ID = 'abc-123';
   });
 
   beforeEach(() => {
@@ -40,7 +40,7 @@ describe('Get candidate summary', () => {
   it('builds applicant employee ID if property is present', async () => {
     const jobPropertiesWithEmployeeId = Object.assign({}, testmodels.sr.jobProperties);
     jobPropertiesWithEmployeeId.data.content.push({
-      id: process.env.SR_EMPLOYEE_PROP_ID,
+      id: config.configParams.SR_EMPLOYEE_PROP_ID,
       value: 12345
     });
     get.mockResolvedValueOnce(jobPropertiesWithEmployeeId);
@@ -63,7 +63,7 @@ describe('Get candidate summary', () => {
 
   function expectSmartRecruitersCalls(get) {
     expect(get.mock.calls[0][0])
-      .toBe(process.env.SR_CANDIDATE_SUMMARY_URL);
+      .toBe(config.configParams.SR_SUMMARY_URL);
     expect(get.mock.calls[1][0])
       .toBe(testmodels.sr.rawCandidateSummaries.data.content[0].actions.details.url);
     expect(get.mock.calls[2][0])
@@ -91,7 +91,7 @@ describe('Add Employee Id property to SR', () => {
   };
 
   beforeAll(() => {
-    process.env.SR_ADD_PROPERTY_URL = 'http://mockurl/';
+    config.configParams.SR_ADD_PROP_URL = 'http://mockurl/';
   });
 
   beforeEach(() => {

--- a/template.yml
+++ b/template.yml
@@ -37,16 +37,6 @@ Resources:
     Properties:
       CodeUri: ./slink-main/
       AutoPublishAlias: STAGE
-      Environment:
-        Variables:
-          SR_API_TOKEN: override_me
-          SR_CANDIDATE_SUMMARY_URL: https://api.smartrecruiters.com/candidates?updatedAfter=2018-02-01T10%3A15%3A00.500%2B00%3A00&status=OFFERED&subStatus=Offer Accepted&limit=100
-          SR_JOB_PROPS_URL: https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties
-          SR_EMPLOYEE_PROP_ID: 05f1b2eb-65f2-46c7-ad73-c7b8bd688c33
-          SR_ADD_PROPERTY_URL: https://api.smartrecruiters.com/candidates/{candidateId}/jobs/{jobId}/properties/{propertyId}
-          SAP_ADD_EMPLOYEE_URL: https://appstore.wipro.com/synergy/AltRecruitService?opr=empIdGen
-          SAP_USERNAME: override_me
-          SAP_PASSWORD: override_me
       Role:
         Fn::ImportValue:
           !Join ['-', [!Ref 'ProjectId', !Ref 'AWS::Region', 'LambdaTrustRole']]

--- a/template.yml
+++ b/template.yml
@@ -76,5 +76,31 @@ Resources:
           - "SlinkIntroductionRule"
           - "Arn"
 
+  ParameterStoreRole:
+      Type: AWS::IAM::Role
+      Properties:
+        AssumeRolePolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            -
+              Effect: Allow
+              Principal:
+                Service:
+                  - 'lambda.amazonaws.com'
+              Action:
+                - 'sts:AssumeRole'
+        ManagedPolicyArns:
+          - 'arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole'
+        Policies:
+          -
+            PolicyName: 'ParameterStoreSlinkAccess'
+            PolicyDocument:
+              Version: '2012-10-17'
+              Statement:
+                -
+                  Effect: Allow
+                  Action:
+                    - 'ssm:GetParameter*'
+                  Resource: !Sub 'arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/slink*'
 
 Transform: AWS::Serverless-2016-10-31


### PR DESCRIPTION
Read all config properties from AWS Parameter Store. This now looks at the Lambda runtime "alias" to determine which environment we are running in (i.e. STAGE or PROD). The code uses this alias to fetch the appropriate parameters from AWS Parameter Store.

**Note**: This runs locally but still needs to be tested in AWS so there might be some tweaks to permissions/IAM roles after merge into main. I just wanted to get the PR reviewed before I push and test in AWS. 

Resolves #53 