### PR TITLE
Attempt to deal better with 429 issues.  Vastly simplify candidate pr…

### DIFF
--- a/slink-main/activation.js
+++ b/slink-main/activation.js
@@ -6,7 +6,7 @@ const activatedApplicantDao = require('./dao/activationsdao');
 const util = require('./util');
 
 const process = async () => {
-  const applicants = await sr.getApplicantsOnboarding();
+  const applicants = await sr.getApplicants({ subStatus: 'ONBOARDING' });
   console.info(`Activation: Collected ${applicants.length} applicants from SmartRecruiters`);
 
   const splitByFte = util.split(applicant => applicant.fullTime === true);

--- a/slink-main/index.js
+++ b/slink-main/index.js
@@ -27,6 +27,7 @@ module.exports.handler = async (event, context, callback) => {
                 `Candidate(s) activated in SAP: ${activationResult.successful}, failed: ${activationResult.unsuccessful}.`
       }
     };
+    console.log('Writing response');
     callback(null, response);
   } catch (e) {
     console.error(`Error in handler:  ${e.message}`);

--- a/slink-main/tests/unit/activation_test.js
+++ b/slink-main/tests/unit/activation_test.js
@@ -16,7 +16,7 @@ util.generateResumeNumber = jest.fn();
 
 describe('Applicant activation process', () => {
   beforeEach(() => {
-    smartrecruiters.getApplicantsOnboarding.mockClear();
+    smartrecruiters.getApplicants.mockClear();
     sapActivateEmployee.execute.mockClear();
     activationsDao.write.mockClear();
   });
@@ -90,7 +90,7 @@ describe('Applicant activation process', () => {
       sapFailApplicant
     ];
 
-    smartrecruiters.getApplicantsOnboarding.mockResolvedValueOnce(applicants);
+    smartrecruiters.getApplicants.mockResolvedValueOnce(applicants);
 
     sapActivateEmployee.execute.mockReturnValueOnce(true);
     sapActivateEmployee.execute.mockReturnValueOnce(true);

--- a/slink-main/tests/unit/smartrecruiters_test.js
+++ b/slink-main/tests/unit/smartrecruiters_test.js
@@ -54,7 +54,7 @@ describe('Get candidate summary', () => {
 
   it('can take different query parameters', async () => {
     const query = {
-      updatedAfter: '2018-07-01', status: 'OFFERED', subStatus: 'onboarding', limit: 100
+      updatedAfter: '2018-07-01', status: 'OFFERED', subStatus: 'onboarding', limit: 15
     };
     get.mockResolvedValueOnce(testmodels.sr.jobProperties);
     const response = await smartrecruiters.getApplicants(query);
@@ -73,7 +73,7 @@ describe('Get candidate summary', () => {
 
   function expectSmartRecruitersCalls(get) {
     expect(get.mock.calls[0][0])
-      .toBe(`${config.params.SR_SUMMARY_URL.value}?${'status=OFFERED&subStatus=Offer Accepted&limit=100'}`);
+      .toBe(`${config.params.SR_SUMMARY_URL.value}?${'status=OFFERED&subStatus=Offer Accepted&limit=15'}`);
     expect(get.mock.calls[1][0])
       .toBe(testmodels.sr.rawCandidateSummaries.data.content[0].actions.details.url);
     expect(get.mock.calls[2][0])


### PR DESCRIPTION
…ocessing code, and a couple other small simplifications.

More on 429s
------------
What has been done is very low-tech:  just request fewer employees from SR for now.  This is really not sufficient, because if we have more than the limit (currently 15) of candidates, and >limit of those candidates are already introduced, there's a chance we will pick up only introduced candidates and thus skip any non-introduced ones in any given run.

The problem is, to find out if a candidate is introduced, we have to do the property GET from SR, so there's a bit of a chicken-and-egg issue trying to avoid the 429, unless we can throttle correctly.

All that said, this commit is just to get the Lambda running again without 429s.  As it is, that's all we ever see, so it's difficult to reason about any other issues that come up.