### PR TITLE
Capture run information at function end (request ID, time, response).

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Adding up all the above, the command to run locally is:
 ```$bash
 LOCAL_DYNAMO_IP=10.1.1.22
 LAST_RUN_DATE_TABLE=LastRunDate \
-RUN_TABLE=Runs \
+RUNS_TABLE=Runs \
 INTRODUCTIONS_TABLE=Introductions \
 ACTIVATIONS_TABLE=Activations \
 sam local invoke SlinkMainFunction -e event.json

--- a/slink-main/aws.js
+++ b/slink-main/aws.js
@@ -14,7 +14,7 @@ const getParams = async (paramPath, awsRegion) => awsParamStore.getParametersByP
 
 const putDynamoDbItem = async (params) => {
   const dynamoDb = createDynamoDb();
-  return dynamoDb.putItem(params).promise();
+  return dynamoDb.put(params).promise();
 };
 
 const getDynamoDbItem = async (params) => {
@@ -24,14 +24,14 @@ const getDynamoDbItem = async (params) => {
 
 function createDynamoDb() {
   if (process.env.LOCAL_DYNAMO_IP === '' || process.env.LOCAL_DYNAMO_IP.length === 0) {
-    return new AWS.DynamoDB();
+    return new AWS.DynamoDB.DocumentClient();
   }
 
   const url = `http://${process.env.LOCAL_DYNAMO_IP}:8000`;
   console.info('NOTE:  Using local DynamoDb url:', url);
   const localEndpoint = { endpoint: new AWS.Endpoint(url) };
 
-  return new AWS.DynamoDB(localEndpoint);
+  return new AWS.DynamoDB.DocumentClient(localEndpoint);
 }
 
 module.exports = {

--- a/slink-main/dao/activationsdao.js
+++ b/slink-main/dao/activationsdao.js
@@ -6,15 +6,9 @@ const config = require('../config');
 async function write({ srCandidateId, sapEmployeeId = 0 } = {}) {
   const params = {
     Item: {
-      srCandidateId: {
-        S: srCandidateId
-      },
-      alias: {
-        S: config.params.LAMBDA_ALIAS.value
-      },
-      sapEmployeeId: {
-        N: `${sapEmployeeId}`
-      }
+      srCandidateId,
+      alias: config.params.LAMBDA_ALIAS.value,
+      sapEmployeeId
     },
     TableName: process.env.ACTIVATIONS_TABLE
   };

--- a/slink-main/dao/introductionsdao.js
+++ b/slink-main/dao/introductionsdao.js
@@ -6,18 +6,10 @@ const config = require('../config');
 async function write({ srCandidateId, slinkResumeNumber = 0, sapEmployeeId = 0 } = {}) {
   const params = {
     Item: {
-      srCandidateId: {
-        S: srCandidateId
-      },
-      alias: {
-        S: config.params.LAMBDA_ALIAS.value
-      },
-      slinkResumeNumber: {
-        S: slinkResumeNumber !== 0 ? `${slinkResumeNumber}` : ''
-      },
-      sapEmployeeId: {
-        N: `${sapEmployeeId}`
-      }
+      srCandidateId,
+      alias: config.params.LAMBDA_ALIAS.value,
+      slinkResumeNumber,
+      sapEmployeeId
     },
     TableName: process.env.INTRODUCTIONS_TABLE
   };

--- a/slink-main/dao/lastrundatedao.js
+++ b/slink-main/dao/lastrundatedao.js
@@ -9,15 +9,9 @@ async function write(requestId, runSerialDate) {
 
   const params = {
     Item: {
-      alias: {
-        S: config.params.LAMBDA_ALIAS.value
-      },
-      requestId: {
-        S: requestId
-      },
-      runSerialDate: {
-        N: `${runSerialDate}`
-      }
+      alias: config.params.LAMBDA_ALIAS.value,
+      requestId,
+      runSerialDate
     },
     TableName: table
   };

--- a/slink-main/dao/runsdao.js
+++ b/slink-main/dao/runsdao.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const aws = require('../aws');
+const config = require('../config');
+
+/**
+ * @param requestId The Lambda request ID
+ * @param runSerialDate Date/time represented as a long value (as returned by `Date.getSerialTime()`).
+ * @param result An object representing the run result (expected to be the response object returned by the Lambda)
+ * @return {Promise<*>}
+ */
+async function write(requestId, runSerialDate, result) {
+  const table = process.env.RUNS_TABLE;
+  console.info(`Writing to table: ${table}`);
+
+  const params = {
+    Item: {
+      requestId,
+      alias: config.params.LAMBDA_ALIAS.value,
+      runSerialDate,
+      result
+    },
+    TableName: table
+  };
+  return aws.putDynamoDbItem(params);
+}
+
+async function read(requestId) {
+  const params = {
+    Key: {
+      requestId: {
+        S: requestId
+      },
+      alias: {
+        S: config.params.LAMBDA_ALIAS.value
+      }
+    },
+    TableName: process.env.RUNS_TABLE
+  };
+  return aws.getDynamoDbItem(params);
+}
+
+module.exports = {
+  write,
+  read
+};
+

--- a/slink-main/tests/unit/dao/activationsdao_test.js
+++ b/slink-main/tests/unit/dao/activationsdao_test.js
@@ -7,7 +7,7 @@ const config = require('../../../config');
 jest.mock('../../../aws');
 jest.mock('../../../config');
 
-describe('Activated Applicant DAO', () => {
+describe('Activations DAO', () => {
   beforeEach(() => {
     config.params.LAMBDA_ALIAS = { value: 'baz' };
     process.env.ACTIVATIONS_TABLE = 'Activations';
@@ -18,22 +18,16 @@ describe('Activated Applicant DAO', () => {
   it('write saves a valid activated applicant item to DynamoDb', async () => {
     await applicantDao.write({
       srCandidateId: 'candidateId',
-      sapEmployeeId: 'employeeId'
+      sapEmployeeId: 12345
     });
 
     const params = {
       Item: {
-        alias: {
-          S: 'baz'
-        },
-        srCandidateId: {
-          S: 'candidateId'
-        },
-        sapEmployeeId: {
-          N: 'employeeId'
-        }
+        alias: 'baz',
+        srCandidateId: 'candidateId',
+        sapEmployeeId: 12345
       },
-      TableName: 'Activations'
+      TableName: 'Activations',
     };
     expect(aws.putDynamoDbItem)
       .toHaveBeenCalledWith(params);

--- a/slink-main/tests/unit/dao/introductionsdao_test.js
+++ b/slink-main/tests/unit/dao/introductionsdao_test.js
@@ -7,7 +7,7 @@ const config = require('../../../config');
 jest.mock('../../../aws');
 jest.mock('../../../config');
 
-describe('Applicant DAO', () => {
+describe('Introductions DAO', () => {
   beforeEach(() => {
     config.params.LAMBDA_ALIAS = { value: 'baz' };
     process.env.INTRODUCTIONS_TABLE = 'Introductions';
@@ -19,23 +19,15 @@ describe('Applicant DAO', () => {
     await applicantDao.write({
       srCandidateId: 'candidateId',
       slinkResumeNumber: 'resumeNumber',
-      sapEmployeeId: 'employeeId'
+      sapEmployeeId: 12345
     });
 
     const params = {
       Item: {
-        alias: {
-          S: 'baz'
-        },
-        srCandidateId: {
-          S: 'candidateId'
-        },
-        slinkResumeNumber: {
-          S: 'resumeNumber'
-        },
-        sapEmployeeId: {
-          N: 'employeeId'
-        }
+        alias: 'baz',
+        srCandidateId: 'candidateId',
+        slinkResumeNumber: 'resumeNumber',
+        sapEmployeeId: 12345
       },
       TableName: 'Introductions'
     };

--- a/slink-main/tests/unit/dao/runsdao_test.js
+++ b/slink-main/tests/unit/dao/runsdao_test.js
@@ -1,40 +1,52 @@
 'use strict';
 
 const aws = require('../../../aws');
-const lastRunDateDao = require('../../../dao/lastrundatedao');
+const runsDao = require('../../../dao/runsdao');
 const config = require('../../../config');
 
 jest.mock('../../../aws');
 jest.mock('../../../config');
 
-describe('Last Run Date DAO', () => {
+describe('Runs DAO', () => {
   beforeEach(() => {
-    process.env.LAST_RUN_DATE_TABLE = 'testing';
+    process.env.RUNS_TABLE = 'testing';
     aws.putDynamoDbItem.mockClear();
   });
 
-  it('write saves a valid run date item to DynamoDb', async () => {
+  it('write saves a valid run item to DynamoDb', async () => {
     config.params.LAMBDA_ALIAS = { value: 'foo' };
 
-    await lastRunDateDao.write('abc123', 12345);
+    await runsDao.write('abc123', 12345, {
+      this: 'this',
+      that: 'that',
+      other: 'other'
+    });
+
     const params = {
       Item: {
-        alias: 'foo',
         requestId: 'abc123',
-        runSerialDate: 12345
+        alias: 'foo',
+        runSerialDate: 12345,
+        result: {
+          this: 'this',
+          that: 'that',
+          other: 'other'
+        }
       },
       TableName: 'testing'
     };
-    expect(aws.putDynamoDbItem)
-      .toHaveBeenCalledWith(params);
+    expect(aws.putDynamoDbItem).toHaveBeenCalledWith(params);
   });
 
   it('read obtains an item from DynamoDb', async () => {
     config.params.LAMBDA_ALIAS = { value: 'foo' };
 
-    await lastRunDateDao.read();
+    await runsDao.read('requestId');
     const params = {
       Key: {
+        requestId: {
+          S: 'requestId'
+        },
         alias: {
           S: 'foo'
         }

--- a/template.yml
+++ b/template.yml
@@ -27,7 +27,7 @@ Resources:
       AutoPublishAlias: STAGE
       Environment:
         Variables:
-          RUN_TABLE: !Ref Runs
+          RUNS_TABLE: !Ref Runs
           LAST_RUN_DATE_TABLE: !Ref LastRunDate
           INTRODUCTIONS_TABLE: !Ref Introductions
           ACTIVATIONS_TABLE: !Ref Activations


### PR DESCRIPTION
Also, big refactoring to use the AWS DynamoDB `DocumentClient` so that writing items is more straightforward.
Resolves #107 